### PR TITLE
Add gpio-spi driver for 74hc595 pin extender.

### DIFF
--- a/package/network/config/ltq-vdsl-app/files/dsl_control
+++ b/package/network/config/ltq-vdsl-app/files/dsl_control
@@ -219,7 +219,29 @@ start_service() {
 	esac
 
 	local annexgpio="/sys/class/gpio/annex"
-	if [ -d "${annexgpio}a" ] && [ -d "${annexgpio}b" ]; then
+	local dsl_en_gpio="/sys/class/gpio/dsl_en"
+	if [ -d "${dsl_en_gpio}" ]; then
+		echo 1 > "${dsl_en_gpio}/value"
+	fi
+	if  [ -d "${annexgpio}a" ] && [ -d "${annexgpio}b" ] && [-d "${annexgpio}j" ]; then
+		case "${annex}" in
+			a*|l*|m*)
+				echo 1 > "${annexgpio}a/value"
+				echo 0 > "${annexgpio}b/value"
+				echo 0 > "${annexgpio}j/value"
+				;;
+			b*)
+				echo 0 > "${annexgpio}a/value"
+				echo 1 > "${annexgpio}b/value"
+				echo 0 > "${annexgpio}j/value"
+				;;
+			i*|j*)
+				echo 0 > "${annexgpio}a/value"
+				echo 0 > "${annexgpio}b/value"
+				echo 1 > "${annexgpio}j/value"
+				;;
+		esac
+	elif [ -d "${annexgpio}a" ] && [ -d "${annexgpio}b" ]; then
 		case "${annex}" in
 			a*|l*|m*)
 				echo 1 > "${annexgpio}a/value"
@@ -313,4 +335,7 @@ stop_service() {
 	DSL_NOTIFICATION_TYPE="DSL_INTERFACE_STATUS" \
 	DSL_INTERFACE_STATUS="DOWN" \
 		/sbin/dsl_notify.sh
+	if [ -d "${dsl_en_gpio}" ]; then
+		echo 0 > "${dsl_en_gpio}/value"
+	fi
 }

--- a/package/network/config/ltq-vdsl-app/files/dsl_control
+++ b/package/network/config/ltq-vdsl-app/files/dsl_control
@@ -335,6 +335,7 @@ stop_service() {
 	DSL_NOTIFICATION_TYPE="DSL_INTERFACE_STATUS" \
 	DSL_INTERFACE_STATUS="DOWN" \
 		/sbin/dsl_notify.sh
+	local dsl_en_gpio="/sys/class/gpio/dsl_en"
 	if [ -d "${dsl_en_gpio}" ]; then
 		echo 0 > "${dsl_en_gpio}/value"
 	fi

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
@@ -122,25 +122,25 @@
 			gpio-export,output = <1>;
 			gpios = <&hc595 3 GPIO_ACTIVE_HIGH>;
 		};
-		out_dsl_eth { /* Switches DSL line + 100MiB eth or 1GiB ethernet on DSL/WAN input*/
+		out_dsl_eth { /* Switches DSL line + 100MiB eth or 1GiB ethernet on DSL/WAN input. Relay 1.*/
 			gpio-export,name = "dsl_en";
 			gpio-export,output = <1>;
-			gpios = <&hc595 4 GPIO_ACTIVE_HIGH>;
+			gpios = <&hc595 4 GPIO_ACTIVE_LOW>;
 		};
-		out_5 { /*Relay*/
-			gpio-export,name = "hc595_5";
+		out_5 { /* Switches filter for DSL line On/Off. Relays 2 and 3 simultaneously.*/
+			gpio-export,name = "annexj";
 			gpio-export,output = <1>;
 			gpios = <&hc595 5 GPIO_ACTIVE_HIGH>;
 		};
-		out_6 { /*Relay*/
-			gpio-export,name = "hc595_6";
+		out_6 { /* Switch DSL line betwean ISDN modem and Si3050. Relay 5.*/
+			gpio-export,name = "annexb";
 			gpio-export,output = <1>;
 			gpios = <&hc595 6 GPIO_ACTIVE_HIGH>;
 		};
-		out_7 { /*Relay*/
-			gpio-export,name = "hc595_7";
+		out_7 { /* Switch phone outputs N and F betwean analog DSL line and XS1 output from Lantiq SLIC. Relay 4.*/
+			gpio-export,name = "annexa";
 			gpio-export,output = <1>;
-			gpios = <&hc595 7 GPIO_ACTIVE_HIGH>;
+			gpios = <&hc595 7 GPIO_ACTIVE_LOW>;
 		};
 	};
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
@@ -78,6 +78,72 @@
 		};
 	};
 
+	spi {
+		compatible = "spi-gpio";
+		address-cells = <1>;
+		size-cells = <0>;
+
+		gpio-sck = <&gpio 29 GPIO_ACTIVE_HIGH >;
+		gpio-mosi = <&gpio 30 GPIO_ACTIVE_HIGH >;
+		num-chipselects = <1>;
+		cs-gpios = <&gpio 39 GPIO_ACTIVE_HIGH >; 
+
+		hc595: gpio_spi@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <1000000>;
+			spi-cpol = <0>;
+			spi-cpha = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		out_0 { /*Unknown*/
+			gpio-export,name = "hc595_0";
+			gpio-export,output = <1>;
+			gpios = <&hc595 0 GPIO_ACTIVE_HIGH>;
+		};
+		out_1 {/*Unknown*/
+			gpio-export,name = "hc595_1";
+			gpio-export,output = <1>;
+			gpios = <&hc595 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		// out_2 is used to reset touch IC and owned by eb904_keypad
+
+		out_3 {/*Unknown*/
+			gpio-export,name = "hc595_3";
+			gpio-export,output = <1>;
+			gpios = <&hc595 3 GPIO_ACTIVE_HIGH>;
+		};
+		out_dsl_eth { /* Switches DSL line + 100MiB eth or 1GiB ethernet on DSL/WAN input*/
+			gpio-export,name = "dsl_en";
+			gpio-export,output = <1>;
+			gpios = <&hc595 4 GPIO_ACTIVE_HIGH>;
+		};
+		out_5 { /*Relay*/
+			gpio-export,name = "hc595_5";
+			gpio-export,output = <1>;
+			gpios = <&hc595 5 GPIO_ACTIVE_HIGH>;
+		};
+		out_6 { /*Relay*/
+			gpio-export,name = "hc595_6";
+			gpio-export,output = <1>;
+			gpios = <&hc595 6 GPIO_ACTIVE_HIGH>;
+		};
+		out_7 { /*Relay*/
+			gpio-export,name = "hc595_7";
+			gpio-export,output = <1>;
+			gpios = <&hc595 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
 	i2c {
 		compatible = "i2c-gpio";
 		#address-cells = <1>;
@@ -95,10 +161,8 @@
 			interrupt-parent = <&icu0>;
 			interrupts = <135>;
 			eb904,interrupt-gpio = <&gpio  0 GPIO_ACTIVE_HIGH /* EXIN */>;
-			eb904,ctrl-clk-gpios = <&gpio 29 GPIO_ACTIVE_HIGH /* clk */>;
-			eb904,ctrl-dat-gpios = <&gpio 30 GPIO_ACTIVE_HIGH /* dat */>;
-			eb904,ctrl-out-gpios = <&gpio 39 GPIO_ACTIVE_HIGH /* out */>;
-			eb904,alphas = /bits/ 8
+			eb904,ctrl-rst-gpio = <&hc595 2 GPIO_ACTIVE_LOW /* rst */>;
+            eb904,alphas = /bits/ 8
 				 <0x07 /* left */
 				  0x0a /* down */
 				  0x0a /* right */
@@ -273,20 +337,6 @@
 *  Following is the very experimental part which is broken and requires much more elaboration
 */
 
-&stp {
-	compatible = "lantiq,gpio-stp-xway";
-	reg = <0xE100BB0 0x40>;
-	#gpio-cells = <2>;
-	gpio-controller;
-
-	lantiq,shadow = <0xffff>;
-	lantiq,groups = <0x7>;
-	lantiq,dsl = <0x3>;
-	lantiq,phy1 = <0x7>;
-	lantiq,phy2 = <0x7>;
-};
-
-
 // From FRITZ3370.dts
 &gpio {
 	pinctrl-names = "default";
@@ -322,6 +372,10 @@
 			lantiq,pins = "io1"; /* exin1 */
 			lantiq,open-drain;
 			lantiq,pull = <0>;
+		};
+		conf_spi {
+			lantiq,pins = "io29", "io30", "io39"; /* gpiois for spi */
+			lantiq,pull = <2>; /*Pull Up*/
 		};
 	};
 };

--- a/vr9_default.config
+++ b/vr9_default.config
@@ -2941,9 +2941,9 @@ CONFIG_PACKAGE_kmod-eeprom-93cx6=y
 # CONFIG_PACKAGE_kmod-eeprom-at25 is not set
 # CONFIG_PACKAGE_kmod-gpio-beeper is not set
 CONFIG_PACKAGE_kmod-gpio-button-hotplug=y
-# CONFIG_PACKAGE_kmod-gpio-dev is not set
+CONFIG_PACKAGE_kmod-gpio-dev=y
 # CONFIG_PACKAGE_kmod-gpio-mcp23s08 is not set
-# CONFIG_PACKAGE_kmod-gpio-nxp-74hc164 is not set
+CONFIG_PACKAGE_kmod-gpio-nxp-74hc164=y
 # CONFIG_PACKAGE_kmod-gpio-pca953x is not set
 # CONFIG_PACKAGE_kmod-gpio-pcf857x is not set
 # CONFIG_PACKAGE_kmod-ikconfig is not set
@@ -2992,9 +2992,9 @@ CONFIG_PACKAGE_kmod-gpio-button-hotplug=y
 # SPI Support
 #
 # CONFIG_PACKAGE_kmod-mmc-spi is not set
-# CONFIG_PACKAGE_kmod-spi-bitbang is not set
+CONFIG_PACKAGE_kmod-spi-bitbang=y
 # CONFIG_PACKAGE_kmod-spi-dev is not set
-# CONFIG_PACKAGE_kmod-spi-gpio is not set
+CONFIG_PACKAGE_kmod-spi-gpio=y
 # CONFIG_PACKAGE_kmod-spi-gpio-custom is not set
 
 #


### PR DESCRIPTION
This PR adds support for 74hc595 gpio extender. It used by touch driver for reset IC.
Additionally this extender is used to control relays to switch filters on DSL line for different annex.
Can disconnect DSL line completely - this will cause 1GiB eth link speed on WAN interface.   
