### PR TITLE
Add .dts entries to make second USB port work on Easybox 904

### DIFF
--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
@@ -344,7 +344,16 @@
     status = "okay";
 };
 
+&usb_phy1 {
+    status = "okay";
+};
+
 &usb0 {
+    status = "okay";
+    vbus-supply = <&usb_vbus>;
+};
+
+&usb1 {
     status = "okay";
     vbus-supply = <&usb_vbus>;
 };


### PR DESCRIPTION
This is a very small .dts change which I think is not invasive.
Checking other .dts/.dtsi files for vr9, it looked like these changes are sufficient to make the 2nd port work.
Tested on my eb904; could mount, read, write, vfat-format an USB stick on the 2nd USB port.

Signed-off-by: arny <arnysch@gmx.net>