### PR TITLE
Fix LED activity level specification in .dts file

### DIFF
--- a/package/base-files/files/etc/rc.local
+++ b/package/base-files/files/etc/rc.local
@@ -1,7 +1,4 @@
 # Put your custom commands here that should be executed once
 # the system init finished. By default this file does nothing.
 
-# Turn off the display at boot time
-echo "1" >/sys/class/backlight/fb_ili9341_eb904/bl_power
-
 exit 0

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
@@ -50,7 +50,7 @@
 		bgr;
 		buswidth = <8>;
 		reset-gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
-		led-gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+		led-gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
 		debug = <1>;
 	};
 
@@ -84,10 +84,11 @@
 	};
 
 	gpio-leds {
-			compatible = "gpio-leds";
-			power_green: power {
+		compatible = "gpio-leds";
+
+		power_green: power {
 			label = "VGV952CJW33:red:power";
-			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
 			default-state = "keep";
 		};
 	};
@@ -97,7 +98,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		gpios = <&gpio 19 GPIO_ACTIVE_HIGH /* sda */
-			&gpio 14 GPIO_ACTIVE_HIGH /* scl */
+ 			&gpio 14 GPIO_ACTIVE_HIGH /* scl */
 		>;
 		//i2c-gpio,sda-open-drain;
 		//i2c-gpio,scl-open-drain;
@@ -337,6 +338,7 @@
 			lantiq,open-drain;
 			lantiq,pull = <0>;
 		};
+
 	};
 };
 


### PR DESCRIPTION
As Henning Schild already found out, the power LED is turned on (i.e.
"active") on high GPIO output level. Same is true for the TFT backlight.
(I think this is unusual; it is different from most other devices)

Up to now it was incorrectly specified in the .dts file, which resulted in
some complications. All software which wanted to turn on a LED needed to
write the nonstandard value 0 into the brightness (for the power LED) or the
bl_power (for the backlight) node in the sysfs.

Of course software controlling the LEDs need to be modified to write the
correct value (e.g. lcdcontroller package) into the sysfs node.

This fix also allows to remove the hack in file rc.local of package
"base-files", where so far the backlight LED is turned off.

Code has been successfully tried out (together with changes in package lcdcontroller).

Note that now on initializing the backlight, it will be turned on for half a second. I have not
searched for the reason why this happens, but I find this not to be a problem.

Signed-off-by: arny <arnysch@gmx.net>
