### PR TITLE
Move driver specific ebu setup to driver, and some cleanup in .dts file

### DIFF
--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV952CJW33-E-IR.dts
@@ -40,20 +40,6 @@
 		reg = <0x0 0x8000000>;
 	};
 
-	easybox904-display{
-		compatible = "ilitek,ili9341_eb904";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		status = "okay";
-		rotate = <270>;
-		fps = <30>;
-		bgr;
-		buswidth = <8>;
-		reset-gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
-		led-gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
-		debug = <1>;
-	};
-
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;
@@ -177,7 +163,7 @@
 			interrupts = <135>;
 			eb904,interrupt-gpio = <&gpio  0 GPIO_ACTIVE_HIGH /* EXIN */>;
 			eb904,ctrl-rst-gpio = <&hc595 2 GPIO_ACTIVE_LOW /* rst */>;
-            eb904,alphas = /bits/ 8
+			eb904,alphas = /bits/ 8
 				 <0x07 /* left */
 				  0x0a /* down */
 				  0x0a /* right */
@@ -248,104 +234,125 @@
 };
 
 &localbus {
-    ranges = <0 0 0x4000000 0x3ffffff>; // Default in vr9.dtsi is crashing the machine.
-    nand@0 {
-            compatible = "lantiq,nand-xway";
-            bank-width = <2>;
-            reg = <0 0x0 0x2000000>;
-            #address-cells = <1>;
-            #size-cells = <1>;
-            lantiq,cs = <1>;			// Seems to be needed (EASY80920NAND.dts)
+    //	#address-cells = <2>;					// Just for info. From vr9.dtsi
+    //	#size-cells = <1>;
+    //	ranges = <0 0 0x0       0x3ffffff			// addrsel0	0x3ffffff and 0x4000010 in vr9.dtsi seem to be wrong, because these are size
+    //    	  1 0 0x4000000 0x4000010>;			// addrsel1	parameters. Not really a problem; the drivers we have use their own hardcoded values
 
-            nand-on-flash-bbt;
-            nand-ecc-strength = <3>;
-            nand-ecc-step-size = <256>;
+	ranges = <0 0 0x0       0x2000000			// addrsel0	Was set up this way by arcadian eb904 U-Boot for nand. Not used by eb904 linux
+		  1 0 0x2000000 0x1000000			// addrsel1	Size 0x1000000 hardcoded in xway_nand.c. Excessive, as first 0x80 is used only
+		  2 0 0x3000000 0x0000800>;			// addrsel2	Size 0x800 hardcoded in display driver. This is the min size supported by ebu
 
-            partitions {
-                compatible = "fixed-partitions";
-                #address-cells = <1>;
-                #size-cells = <1>;
-                partition@0 {
-                    label = "uboot";
-                    reg = <0x0 0x40000>;
-                };
+	nand@1 {						// @1 because using ebu BUSCON1/ADDSEL1
+		compatible = "lantiq,nand-xway";
+		reg = <1 0x0 0x80>;				// Only adresses 0x0..0x7F needed (but driver ignores size 0x80 and tells ebu to map 0x1000000)
 
-                partition@40000 {
-                    label = "rootfs1";		// Called "rootfs" in original u-boot env.
-                    reg = <0x40000 0x3C00000>;	// Auto mounted as rootfs if no UBI volume named "rootfs" exists
-                };
+	    //	bank-width = <2>;				// Not used by any driver code
+		#address-cells = <1>;
+		#size-cells = <1>;
+		lantiq,cs = <1>;				// Seems to be needed (EASY80920NAND.dts)
 
-                partition@3C40000 {
-                    label = "kernel";		// Called "kernel" in original u-boot env.
-                    reg = <0x3C40000 0x500000>;
-                };
+		nand-on-flash-bbt;
 
-                partition@4140000 {
-                    label = "tmp1";
-                    reg = <0x4140000 0x100000>;
-                };
+		partitions {
+		compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-                partition@4240000 {
-                    label = "tmp2";
-                    reg = <0x4240000 0x200000>;
-                };
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x40000>;
+			};
 
-                partition@4440000 {
-                    label = "sysconfig";
-                    reg = <0x4440000 0x100000>;
-                };
+			partition@40000 {
+				label = "rootfs1";		// Called "rootfs" in original u-boot env.
+				reg = <0x40000 0x3C00000>;	// Auto mounted as rootfs if no UBI volume named "rootfs" exists
+			};
 
-                partition@4540000 {
-                    label = "ubootconfig";
-                    reg = <0x4540000 0x100000>;
-                };
+			partition@3C40000 {
+				label = "kernel";		// Called "kernel" in original u-boot env.
+				reg = <0x3C40000 0x500000>;
+			};
 
-                partition@4640000 {
-                    label = "fwdiag";
-                    reg = <0x4640000 0xC0000>;
-                };
+			partition@4140000 {
+				label = "tmp1";
+				reg = <0x4140000 0x100000>;
+			};
 
-                partition@4700000 {
-                    label = "lcdimage";
-                    reg = <0x4700000 0x300000>;
-                };
+			partition@4240000 {
+				label = "tmp2";
+				reg = <0x4240000 0x200000>;
+			};
 
-                partition@4A00000 {
-                    label = "mfgconfig";
-                    reg = <0x4A00000 0x100000>;
-                };
+			partition@4440000 {
+				label = "sysconfig";
+				reg = <0x4440000 0x100000>;
+			};
 
-                partition@4B00000 {
-                    label = "sipdata";
-                    reg = <0x4B00000 0x100000>;
-                };
+			partition@4540000 {
+				label = "ubootconfig";
+				reg = <0x4540000 0x100000>;
+			};
 
-                partition@4C00000 {
-                    label = "voice";
-                    reg = <0x4C00000 0x4000000>;
-                };
+			partition@4640000 {
+				label = "fwdiag";
+				reg = <0x4640000 0xC0000>;
+			};
 
-                partition@8C00000 {			// Called "misc" in original u-boot env.
-                    label = "ubi";			// Rename to "ubi" for auto ubi attachment and usage of rootfs, rootfs_data, kernel volumes
-                    reg = <0x8C00000 0x13200000>;	// Rename to "firmware" for special squashfs-rootfs/jffs2-rootfs_data treatment
-                };
+			partition@4700000 {
+				label = "lcdimage";
+				reg = <0x4700000 0x300000>;
+			};
 
-                partition@1BE00000 {
-                    label = "rootfs2";
-                    reg = <0x1BE00000 0x3c00000>;
-                };
+			partition@4A00000 {
+				label = "mfgconfig";
+				reg = <0x4A00000 0x100000>;
+			};
 
-                partition@1FA00000 {
-                    label = "kernel2";
-                    reg = <0x1FA00000 0x500000>;
-                };
+			partition@4B00000 {
+				label = "sipdata";
+				reg = <0x4B00000 0x100000>;
+			};
 
-                partition@1FF00000 {
-                    label = "mystery";		// Missing in original u-boot environment, seems to be empty (erased)
-                    reg = <0x1FF00000 0x100000>;
-                };
-            };
-    };
+			partition@4C00000 {
+				label = "voice";
+				reg = <0x4C00000 0x4000000>;
+			};
+
+			partition@8C00000 {			// Called "misc" in original u-boot env.
+				label = "ubi";			// Rename to "ubi" for auto ubi attachment and usage of rootfs, rootfs_data, kernel volumes
+				reg = <0x8C00000 0x13200000>;	// Rename to "firmware" for special squashfs-rootfs/jffs2-rootfs_data treatment
+			};
+
+			partition@1BE00000 {
+				label = "rootfs2";
+				reg = <0x1BE00000 0x3c00000>;
+			};
+
+			partition@1FA00000 {
+				label = "kernel2";
+				reg = <0x1FA00000 0x500000>;
+			};
+
+			partition@1FF00000 {
+				label = "mystery";		// Missing in original u-boot environment, seems to be empty (erased)
+				reg = <0x1FF00000 0x100000>;
+			};
+		};
+	};
+
+	display@2 {						// @2 because using ebu BUSCON2/ADDSEL2. Name not 'easybox904-display',
+		compatible = "ilitek,ili9341_eb904";		// see 'Node Names' at https://elinux.org/Device_Tree_Usage
+		reg = <2 0x0 0x4>;				// Size 0x4 contains 2 byte data and 2 byte command registers
+		status = "okay";
+		rotate = <270>;
+		fps = <30>;
+		bgr;
+		buswidth = <8>;
+		reset-gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		led-gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
+		debug = <1>;
+	};
 };
 
 /*
@@ -373,7 +380,7 @@
 
 		pcie-rst {
 			lantiq,pins = "io38";				// FRITZ3370.dts, TDW8970.dts, EASY80920.dtsi, P2812HNUFX.dtsi
-		   //  	lantiq,pins = "io21";				// ARV7519RW22.dts
+		   //	lantiq,pins = "io21";				// ARV7519RW22.dts
 			lantiq,pull = <0>;
 			lantiq,output = <1>;
 		};
@@ -396,21 +403,21 @@
 };
 
 &usb_phy0 {
-    status = "okay";
+	status = "okay";
 };
 
 &usb_phy1 {
-    status = "okay";
+	status = "okay";
 };
 
 &usb0 {
-    status = "okay";
-    vbus-supply = <&usb_vbus>;
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
 };
 
 &usb1 {
-    status = "okay";
-    vbus-supply = <&usb_vbus>;
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
 };
 
 &eth0 {

--- a/target/linux/lantiq/patches-4.14/4050-MIPS-lantiq-EBU-set_buscon_params.patch
+++ b/target/linux/lantiq/patches-4.14/4050-MIPS-lantiq-EBU-set_buscon_params.patch
@@ -11,14 +11,22 @@
  /* WDT */
 --- a/arch/mips/lantiq/xway/sysctrl.c
 +++ b/arch/mips/lantiq/xway/sysctrl.c
-@@ -514,6 +514,10 @@ void __init ltq_soc_init(void)
+@@ -147,7 +147,9 @@
  
- 	/* make sure to unprotect the memory region where flash is located */
+ static void __iomem *pmu_membase;
+ void __iomem *ltq_cgu_membase;
++
+ void __iomem *ltq_ebu_membase;
++EXPORT_SYMBOL(ltq_ebu_membase);
+ 
+ static u32 ifccr = CGU_IFCCR;
+ static u32 pcicr = CGU_PCICR;
+@@ -474,7 +476,7 @@
+ 	if (!pmu_membase || !ltq_cgu_membase || !ltq_ebu_membase)
+ 		panic("Failed to remap core resources");
+ 
+-	/* make sure to unprotect the memory region where flash is located */
++	/* make sure to unprotect the memory region where NOR flash is located */
  	ltq_ebu_w32(ltq_ebu_r32(LTQ_EBU_BUSCON0) & ~EBU_WRDIS, LTQ_EBU_BUSCON0);
-+	printk("%s:%s:%d LTQ_EBU_BUSCON2: 0x%08x\n",__FILE__,__FUNCTION__,__LINE__, ltq_ebu_r32(LTQ_EBU_BUSCON2));
-+	//ltq_ebu_w32(0x0001d7ff, LTQ_EBU_BUSCON2); // U-Boot setting
-+	ltq_ebu_w32(0x0001d3dd, LTQ_EBU_BUSCON2);   // init script setting
-+	printk("%s:%s:%d LTQ_EBU_BUSCON2: 0x%08x\n",__FILE__,__FUNCTION__,__LINE__, ltq_ebu_r32(LTQ_EBU_BUSCON2));
  
  	/* add our generic xway clocks */
- 	clkdev_add_pmu("10000000.fpi", NULL, 0, 0, PMU_FPI);


### PR DESCRIPTION
- Remove eb904 specific stuff from common file lantiq/xway/sysctrl.c.
Export ltq_ebu_membase so eb904 display driver can do driver specific ebu setup
(like it is done by the nand driver in xway_nand.c).

- Some cleanup in .dts file. Moved display into localbus section to show connection to ebu, and to specify mapping parameters. Added comments to .dts in order to explain why s.th. has been done.

Signed-off-by: arny <arnysch@gmx.net>
